### PR TITLE
added Deezer, Qobuz and Tidal

### DIFF
--- a/css/brands-extended.css
+++ b/css/brands-extended.css
@@ -134,6 +134,26 @@ button:hover,
   filter: brightness(90%);
 }
 
+/* Deezer */
+.button.button-deezer {
+  color: #ffffff;
+  background-color: #181818;
+}
+.button.button-deezer:hover,
+.button.button-deezer:focus {
+  filter: brightness(90%);
+}
+
+/* Deezer Alt */
+.button.button-deezer-alt {
+  color: #ffffff;
+  background-color: #181818;
+}
+.button.button-deezer-alt:hover,
+.button.button-deezer-alt:focus {
+  filter: brightness(90%);
+}
+
 /* Devpost */
 .button.button-devpost {
   color: #ffffff;
@@ -251,6 +271,16 @@ button:hover,
   filter: brightness(90%);
 }
 
+/* Qobuz */
+.button.button-qobuz {
+  color: #ffffff;
+  background-color: #000000;
+}
+.button.button-qobuz:hover,
+.button.button-qobuz:focus {
+  filter: brightness(90%);
+}
+
   /* ResearchGate */
 .button.button-researchgate {
   color: #000000;
@@ -269,6 +299,16 @@ button:hover,
 }
 .button.button-spacehey:hover,
 .button.button-spacehey:focus {
+  filter: brightness(90%);
+}
+
+/* Tidal */
+.button.button-tidal {
+  color: #ffffff;
+  background-color: #000000;
+}
+.button.button-tidal:hover,
+.button.button-tidal:focus {
   filter: brightness(90%);
 }
 

--- a/images/icons-extended/deezer-alt.svg
+++ b/images/icons-extended/deezer-alt.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499999 6.35"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="deezer-alt.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.5857476"
+     inkscape:cx="-4.099013"
+     inkscape:cy="37.837043"
+     inkscape:window-width="1472"
+     inkscape:window-height="449"
+     inkscape:window-x="130"
+     inkscape:window-y="597"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       d="M 6.35,1.1009147 H 4.9770171 v 0.801212 H 6.35 Z"
+       fill="#ffffff"
+       id="path1"
+       style="stroke-width:0.0552942" />
+    <path
+       d="M 6.35,2.2167507 H 4.9770171 V 3.0179638 H 6.35 Z"
+       fill="#ffffff"
+       id="path2"
+       style="stroke-width:0.0552942" />
+    <path
+       d="M 6.35,3.332035 H 4.9770171 V 4.1332481 H 6.35 Z"
+       fill="#ffffff"
+       id="path3"
+       style="stroke-width:0.0552942" />
+    <path
+       d="M 1.3729571,4.4478721 H -1.174514e-8 V 5.2490852 H 1.3729571 Z"
+       fill="#ffffff"
+       id="path4"
+       style="stroke-width:0.0552942" />
+    <path
+       d="M 3.0317834,4.4478721 H 1.6588282 v 0.8012131 h 1.3729552 z"
+       fill="#ffffff"
+       id="path5"
+       style="stroke-width:0.0552942" />
+    <path
+       d="M 4.6911461,4.4478721 H 3.3181908 v 0.8012131 h 1.3729553 z"
+       fill="#ffffff"
+       id="path6"
+       style="stroke-width:0.0552942" />
+    <path
+       d="M 6.35,4.4478721 H 4.9770171 V 5.2490852 H 6.35 Z"
+       fill="#ffffff"
+       id="path7"
+       style="stroke-width:0.0552942" />
+    <path
+       d="M 4.6911461,3.332035 H 3.3181908 v 0.8012131 h 1.3729553 z"
+       fill="#ffffff"
+       id="path8"
+       style="stroke-width:0.0552942" />
+    <path
+       d="M 3.0317834,3.332035 H 1.6588282 v 0.8012131 h 1.3729552 z"
+       fill="#ffffff"
+       id="path9"
+       style="stroke-width:0.0552942" />
+    <path
+       d="M 3.0317834,2.2167507 H 1.6588282 v 0.8012131 h 1.3729552 z"
+       fill="#ffffff"
+       id="path10"
+       style="stroke-width:0.0552942" />
+  </g>
+</svg>

--- a/images/icons-extended/deezer.svg
+++ b/images/icons-extended/deezer.svg
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499999 6.35"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="deezer.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="11.949153"
+     inkscape:cy="12"
+     inkscape:window-width="1472"
+     inkscape:window-height="449"
+     inkscape:window-x="0"
+     inkscape:window-y="371"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1" />
+  <defs
+     id="defs1">
+    <linearGradient
+       id="paint0_linear"
+       x1="104.55"
+       y1="37.09"
+       x2="101.32"
+       y2="18.790001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05529421,0,0,0.05529421,-0.02818712,1.0721606)">
+      <stop
+         stop-color="#2C8C9D"
+         id="stop10" />
+      <stop
+         offset="0.04"
+         stop-color="#298E9A"
+         id="stop11" />
+      <stop
+         offset="0.39"
+         stop-color="#129C83"
+         id="stop12" />
+      <stop
+         offset="0.72"
+         stop-color="#05A475"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-color="#00A770"
+         id="stop14" />
+    </linearGradient>
+    <linearGradient
+       id="paint1_linear"
+       x1="90.149498"
+       y1="54.630001"
+       x2="115.72"
+       y2="41.599998"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05529421,0,0,0.05529421,-0.02818712,1.0721606)">
+      <stop
+         stop-color="#2839BA"
+         id="stop15" />
+      <stop
+         offset="1"
+         stop-color="#148CB3"
+         id="stop16" />
+    </linearGradient>
+    <linearGradient
+       id="paint2_linear"
+       x1="0.50976598"
+       y1="68.290001"
+       x2="25.3398"
+       y2="68.290001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05529421,0,0,0.05529421,-0.02818712,1.0721606)">
+      <stop
+         stop-color="#F6A500"
+         id="stop17" />
+      <stop
+         offset="1"
+         stop-color="#F29100"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="paint3_linear"
+       x1="30.5098"
+       y1="68.290001"
+       x2="55.339802"
+       y2="68.290001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05529421,0,0,0.05529421,-0.02818712,1.0721606)">
+      <stop
+         stop-color="#F29100"
+         id="stop19" />
+      <stop
+         offset="1"
+         stop-color="#D12F5F"
+         id="stop20" />
+    </linearGradient>
+    <linearGradient
+       id="paint4_linear"
+       x1="60.519501"
+       y1="68.290001"
+       x2="85.349503"
+       y2="68.290001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05529421,0,0,0.05529421,-0.02818712,1.0721606)">
+      <stop
+         stop-color="#B4197C"
+         id="stop21" />
+      <stop
+         offset="1"
+         stop-color="#472EAD"
+         id="stop22" />
+    </linearGradient>
+    <linearGradient
+       id="paint5_linear"
+       x1="90.519501"
+       y1="68.290001"
+       x2="115.35"
+       y2="68.290001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05529421,0,0,0.05529421,-0.02818712,1.0721606)">
+      <stop
+         stop-color="#2839BA"
+         id="stop23" />
+      <stop
+         offset="1"
+         stop-color="#3072B7"
+         id="stop24" />
+    </linearGradient>
+    <linearGradient
+       id="paint6_linear"
+       x1="59.539501"
+       y1="52.029999"
+       x2="86.319504"
+       y2="44.200001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05529421,0,0,0.05529421,-0.02818712,1.0721606)">
+      <stop
+         stop-color="#B4197C"
+         id="stop25" />
+      <stop
+         offset="1"
+         stop-color="#373AAC"
+         id="stop26" />
+    </linearGradient>
+    <linearGradient
+       id="paint7_linear"
+       x1="29.639799"
+       y1="43.279999"
+       x2="56.219799"
+       y2="52.950001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05529421,0,0,0.05529421,-0.02818712,1.0721606)">
+      <stop
+         stop-color="#FFCB00"
+         id="stop27" />
+      <stop
+         offset="1"
+         stop-color="#D12F5F"
+         id="stop28" />
+    </linearGradient>
+    <linearGradient
+       id="paint8_linear"
+       x1="32.609798"
+       y1="18.419901"
+       x2="53.239799"
+       y2="37.4599"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05529421,0,0,0.05529421,-0.02818712,1.0721606)">
+      <stop
+         stop-color="#FFCF00"
+         id="stop29" />
+      <stop
+         offset="1"
+         stop-color="#ED743B"
+         id="stop30" />
+    </linearGradient>
+  </defs>
+  <g
+     id="layer1">
+    <path
+       d="M 6.35,1.1009147 H 4.9770171 v 0.801212 H 6.35 Z"
+       fill="#29ab70"
+       id="path1"
+       style="stroke-width:0.0552942" />
+    <path
+       d="M 6.35,2.2167507 H 4.9770171 V 3.0179638 H 6.35 Z"
+       fill="url(#paint0_linear)"
+       id="path2"
+       style="fill:url(#paint0_linear);stroke-width:0.0552942" />
+    <path
+       d="M 6.35,3.332035 H 4.9770171 V 4.1332481 H 6.35 Z"
+       fill="url(#paint1_linear)"
+       id="path3"
+       style="fill:url(#paint1_linear);stroke-width:0.0552942" />
+    <path
+       d="M 1.3729571,4.4478721 H -1.174514e-8 V 5.2490852 H 1.3729571 Z"
+       fill="url(#paint2_linear)"
+       id="path4"
+       style="fill:url(#paint2_linear);stroke-width:0.0552942" />
+    <path
+       d="M 3.0317834,4.4478721 H 1.6588282 v 0.8012131 h 1.3729552 z"
+       fill="url(#paint3_linear)"
+       id="path5"
+       style="fill:url(#paint3_linear);stroke-width:0.0552942" />
+    <path
+       d="M 4.6911461,4.4478721 H 3.3181908 v 0.8012131 h 1.3729553 z"
+       fill="url(#paint4_linear)"
+       id="path6"
+       style="fill:url(#paint4_linear);stroke-width:0.0552942" />
+    <path
+       d="M 6.35,4.4478721 H 4.9770171 V 5.2490852 H 6.35 Z"
+       fill="url(#paint5_linear)"
+       id="path7"
+       style="fill:url(#paint5_linear);stroke-width:0.0552942" />
+    <path
+       d="M 4.6911461,3.332035 H 3.3181908 v 0.8012131 h 1.3729553 z"
+       fill="url(#paint6_linear)"
+       id="path8"
+       style="fill:url(#paint6_linear);stroke-width:0.0552942" />
+    <path
+       d="M 3.0317834,3.332035 H 1.6588282 v 0.8012131 h 1.3729552 z"
+       fill="url(#paint7_linear)"
+       id="path9"
+       style="fill:url(#paint7_linear);stroke-width:0.0552942" />
+    <path
+       d="M 3.0317834,2.2167507 H 1.6588282 v 0.8012131 h 1.3729552 z"
+       fill="url(#paint8_linear)"
+       id="path10"
+       style="fill:url(#paint8_linear);stroke-width:0.0552942" />
+  </g>
+</svg>

--- a/images/icons-extended/qobuz.svg
+++ b/images/icons-extended/qobuz.svg
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499999 6.35"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="qobuz.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.1843797"
+     inkscape:cx="81.477248"
+     inkscape:cy="32.928629"
+     inkscape:window-width="1472"
+     inkscape:window-height="449"
+     inkscape:window-x="238"
+     inkscape:window-y="570"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <linearGradient
+       id="SVGID_1_"
+       gradientUnits="userSpaceOnUse"
+       x1="4.8269"
+       y1="-1172.4808"
+       x2="26.038601"
+       y2="-1172.4808"
+       gradientTransform="matrix(1,0,0,-1,0,-1158)">&#10;				<stop
+   offset="0"
+   style="stop-color:#000000"
+   id="stop2" />
+&#10;				<stop
+   offset="0.5108"
+   style="stop-color:#DFDFDF"
+   id="stop3" />
+&#10;				<stop
+   offset="0.8763"
+   style="stop-color:#000000"
+   id="stop4" />
+&#10;			</linearGradient>
+    <linearGradient
+       id="SVGID_2_"
+       gradientUnits="userSpaceOnUse"
+       x1="15.1016"
+       y1="-1168.1337"
+       x2="23.4181"
+       y2="-1175.3818"
+       gradientTransform="matrix(1,0,0,-1,0,-1158)">&#10;				<stop
+   offset="0.0029"
+   style="stop-color:#B5B5B5;stop-opacity:0"
+   id="stop5" />
+&#10;				<stop
+   offset="0.1244"
+   style="stop-color:#969696;stop-opacity:0.1632"
+   id="stop6" />
+&#10;				<stop
+   offset="0.5553"
+   style="stop-color:#2B2B2B;stop-opacity:0.7421"
+   id="stop7" />
+&#10;				<stop
+   offset="0.7473"
+   style="stop-color:#000000"
+   id="stop8" />
+&#10;			</linearGradient>
+    <linearGradient
+       id="SVGID_3_"
+       gradientUnits="userSpaceOnUse"
+       x1="66.594398"
+       y1="-1168.1345"
+       x2="74.909897"
+       y2="-1175.3818"
+       gradientTransform="rotate(180,41.1796,-579)">&#10;				<stop
+   offset="0.0029"
+   style="stop-color:#B5B5B5;stop-opacity:0"
+   id="stop9" />
+&#10;				<stop
+   offset="0.1244"
+   style="stop-color:#969696;stop-opacity:0.1632"
+   id="stop10" />
+&#10;				<stop
+   offset="0.5553"
+   style="stop-color:#2B2B2B;stop-opacity:0.7421"
+   id="stop11" />
+&#10;				<stop
+   offset="0.7473"
+   style="stop-color:#000000"
+   id="stop12" />
+&#10;			</linearGradient>
+    <linearGradient
+       id="SVGID_4_"
+       gradientUnits="userSpaceOnUse"
+       x1="16.7614"
+       y1="-1191.3518"
+       x2="24.542999"
+       y2="-1186.0513"
+       gradientTransform="matrix(1,0,0,-1,0,-1158)">&#10;				<stop
+   offset="0.0029"
+   style="stop-color:#B5B5B5;stop-opacity:0"
+   id="stop13" />
+&#10;				<stop
+   offset="0.0486"
+   style="stop-color:#A8A8A8;stop-opacity:0.0514"
+   id="stop14" />
+&#10;				<stop
+   offset="0.2682"
+   style="stop-color:#6C6C6C;stop-opacity:0.2982"
+   id="stop15" />
+&#10;				<stop
+   offset="0.4258"
+   style="stop-color:#3E3E3E;stop-opacity:0.5252"
+   id="stop16" />
+&#10;				<stop
+   offset="0.5591"
+   style="stop-color:#1C1C1C;stop-opacity:0.725"
+   id="stop17" />
+&#10;				<stop
+   offset="0.7208"
+   style="stop-color:#070707;stop-opacity:0.8901"
+   id="stop18" />
+&#10;				<stop
+   offset="0.8679"
+   style="stop-color:#000000"
+   id="stop19" />
+&#10;			</linearGradient>
+  </defs>
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g27"
+       transform="matrix(0.20404884,0,0,0.20404884,0.00408103,-0.91230231)">&#10;	<path
+   d="m 27.798,29.11 c 1.918,-2.572 3.067,-5.751 3.067,-9.206 C 30.865,11.381 23.956,4.471 15.432,4.471 6.909,4.471 0,11.38 0,19.903 c 0,8.523 6.909,15.433 15.433,15.433 3.442,0 6.61,-1.141 9.177,-3.046 l -0.046,0.055 3.147,3.246 3.369,-3.246 z"
+   id="path1" />
+<circle
+   fill="#ffffff"
+   cx="15.433"
+   cy="19.903"
+   r="14.258"
+   id="circle1" />
+<path
+   d="m 15.433,8.421 c -6.342,0 -11.483,5.141 -11.483,11.483 0,6.342 5.141,11.483 11.483,11.483 6.342,0 11.483,-5.141 11.483,-11.483 0,-6.342 -5.142,-11.483 -11.483,-11.483 z m 0,15.999 c -2.495,0 -4.517,-2.022 -4.517,-4.517 0,-2.495 2.022,-4.517 4.517,-4.517 2.495,0 4.517,2.022 4.517,4.517 0,2.495 -2.023,4.517 -4.517,4.517 z"
+   id="path2" />
+<circle
+   cx="15.433"
+   cy="19.903"
+   r="0.98000002"
+   id="circle2" />
+<path
+   fill="url(#SVGID_1_)"
+   d="m 9.942,19.67 c 0.122,-2.927 2.533,-5.263 5.49,-5.263 2.957,0 5.368,2.336 5.49,5.263 h 5.115 C 25.913,13.917 21.214,9.292 15.431,9.292 9.648,9.292 4.951,13.918 4.827,19.67 Z"
+   id="path4"
+   style="fill:url(#SVGID_1_)" />
+<path
+   fill="url(#SVGID_2_)"
+   d="m 15.433,9.293 v 5.115 c 2.958,0.037 5.422,2.41 5.493,5.36 h 5.115 C 25.969,13.994 21.216,9.331 15.433,9.293 Z"
+   id="path8"
+   style="fill:url(#SVGID_2_)" />
+<path
+   fill="url(#SVGID_3_)"
+   d="m 15.433,9.293 v 5.115 c -2.958,0.037 -5.419,2.41 -5.49,5.36 H 4.827 C 4.899,13.994 9.65,9.331 15.433,9.293 Z"
+   id="path12"
+   style="fill:url(#SVGID_3_)" />
+<path
+   fill="url(#SVGID_4_)"
+   d="m 22.994,28.541 c -2.02,1.77 -4.665,2.845 -7.562,2.845 -0.012,0 -0.023,-10e-4 -0.034,-10e-4 v 2.775 c 0.012,0 0.023,0.001 0.034,0.001 3.593,0 6.874,-1.332 9.381,-3.526 -0.6,-0.703 -1.226,-1.386 -1.819,-2.094 z"
+   id="path19"
+   style="fill:url(#SVGID_4_)" />
+<path
+   fill="#ffffff"
+   d="m 29.527,32.372 -7.691,-7.708 c -0.227,-0.301 -0.586,-0.496 -0.991,-0.496 -0.686,0 -1.242,0.556 -1.242,1.242 0,0.334 0.133,0.637 0.348,0.861 v 0 0 c 0.014,0.015 0.03,0.03 0.045,0.044 l 7.838,7.663 z"
+   id="path20" />
+&#10;	&#10;</g>
+  </g>
+</svg>

--- a/images/icons-extended/tidal.svg
+++ b/images/icons-extended/tidal.svg
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499999 6.35"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="tidal.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="2.3063374"
+     inkscape:cx="-71.542003"
+     inkscape:cy="-5.6366426"
+     inkscape:window-width="1472"
+     inkscape:window-height="449"
+     inkscape:window-x="0"
+     inkscape:window-y="371"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke-width:0.00612995"
+       id="rect1"
+       width="1.4967093"
+       height="1.4967093"
+       x="2.993422"
+       y="-1.4967088"
+       transform="rotate(45)" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke-width:0.00612995"
+       id="rect2"
+       width="1.4967093"
+       height="1.4967093"
+       x="4.4901333"
+       y="-2.9934196"
+       transform="rotate(45)" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke-width:0.00612995"
+       id="rect3"
+       width="1.4967093"
+       height="1.4967093"
+       x="1.4967111"
+       y="-1.8475748e-06"
+       transform="rotate(45)" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke-width:0.00612995"
+       id="rect4"
+       width="1.4967093"
+       height="1.4967093"
+       x="4.4901333"
+       y="-1.8475748e-06"
+       transform="rotate(45)" />
+  </g>
+</svg>

--- a/preview.html
+++ b/preview.html
@@ -122,6 +122,16 @@
             <img class="icon" src="images/icons-extended/codepen.svg" alt="Codepen Logo">Codepen</a>
         <br>
 
+        <!-- Deezer -->
+        <a class="button button-deezer" href="#" target="_blank" rel="noopener">
+            <img class="icon" src="images/icons-extended/deezer.svg" alt="Deezer Logo">Listen on Deezer</a>
+        <br> 
+
+        <!-- Deezer Alt -->
+        <a class="button button-deezer-alt" href="#" target="_blank" rel="noopener">
+            <img class="icon" src="images/icons-extended/deezer-alt.svg" alt="Deezer Alt Logo">Listen on Deezer</a>
+        <br>
+
         <!-- Devpost -->
         <a class="button button-devpost" href="#" target="_blank" rel="noopener">
             <img class="icon icon-invert" src="images/icons-extended/devpost.svg" alt="Devpost Logo">Devpost</a>
@@ -150,6 +160,11 @@
         <!-- Lemmy -->
         <a class="button button-lemmy" href="#" target="_blank" rel="noopener">
           <img class="icon" src="images/icons-extended/lemmy.svg" alt="Lemmy Logo">Lemmy</a>
+        <br>
+
+        <!-- Qobuz -->
+        <a class="button button-qobuz" href="#" target="_blank" rel="noopener">
+            <img class="icon" src="images/icons-extended/qobuz.svg" alt="Qobuz Logo">Listen on Qobuz</a>
         <br>
 
         <!-- Matrix -->
@@ -196,6 +211,11 @@
         <a class="button button-spacehey" href="#" target="_blank" rel="noopener">
             <img class="icon" src="images/icons-extended/spacehey.svg" alt="SpaceHey Logo">SpaceHey</a>
         <br>
+
+        <!-- Tidal -->
+        <a class="button button-tidal" href="#" target="_blank" rel="noopener">
+            <img class="icon" src="images/icons-extended/tidal.svg" alt="Tidal Logo">Listen on Tidal</a>
+        <br> 
 
         <!-- Vero -->
         <a class="button button-vero" href="#" target="_blank" rel="noopener">


### PR DESCRIPTION
I added links to 3 global music streaming providers (Deezer, Qobuz and Tidal). I am not quite sure those providers are wide enough to be included into the core littlelink repo (in that case, tell me and I can prepare a pull request for the other repo).
SVG files were prepared wik InkScape, which can be messy in the headers data; but to clean it up I needs to be manually done.

For Deezer (https://www.deezer.com/), I used their own svg file, rescaled-down. Background color inherited from their logo on the Apple App Store. But because I think it's not readable enough, I used their monochrome version to make the Alt version.

Qobuz (https://www.qobuz.com/)

Tidal (https://tidal.com/)

For those links, in the text of the buttons, I used "Listen on ...", as seen for other music streaming providers on the core littlelink repo.