### PR TITLE
Add Knocket brand button

### DIFF
--- a/css/brands-extended.css
+++ b/css/brands-extended.css
@@ -214,6 +214,13 @@
   --button-border:1px solid #000000;
 }
 
+/* Knocket */
+.button-knocket {
+  --button-text:#FFFFFF;
+  --button-background:#1E8FFF;
+  --button-border:1px solid #FFFFFF;
+}
+
 /* Layers */
 .button-layers {
   --button-text:#000000;

--- a/images/icons-extended/knocket.svg
+++ b/images/icons-extended/knocket.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="24" height="24">
+  <ellipse cx="28" cy="48" rx="20" ry="24" fill="#1E8FFF"/>
+  <path d="M48 18 L68 18 Q78 18 73 28 L58 55 Q53 65 48 55 Z" fill="#16C4FF"/>
+  <path d="M60 45 L65 35 Q70 25 75 35 L80 82 Q82 92 72 88 L65 85 Q55 80 58 70 Z" fill="#1A52E8"/>
+</svg>

--- a/preview.html
+++ b/preview.html
@@ -148,6 +148,9 @@
               <!-- Keybase -->
               <a class="button button-keybase" href="#" target="_blank" rel="noopener" role="button"><img class="icon" aria-hidden="true" src="images/icons-extended/keybase.svg" alt="Keybase Logo">Keybase</a>
 
+              <!-- Knocket -->
+              <a class="button button-knocket" href="https://knocket.io/p/yourname" target="_blank" rel="noopener" role="button"><img class="icon" aria-hidden="true" src="images/icons-extended/knocket.svg" alt="Knocket Logo">Knocket</a>
+
               <!-- Layers -->
               <a class="button button-layers" href="#" target="_blank" rel="noopener" role="button"><img class="icon" aria-hidden="true" src="images/icons-extended/layers.svg" alt="Layers Logo">Layers</a>
 


### PR DESCRIPTION
Adds a **Knocket** brand button.

Knocket is a free contact page and live chat tool — users get a shareable `knocket.io/p/yourname` URL with live chat, social links and booking in one card. This adds a button so people can link to their Knocket contact page from their LittleLink page.

### Changes
- `css/brands-extended.css` — `.button-knocket` brand class (added alphabetically)
- `images/icons-extended/knocket.svg` — brand icon
- `preview.html` — Knocket button example (added alphabetically)

Brand color: `#1E8FFF`. More info: https://trtc.io/solutions/knocket